### PR TITLE
fix: change parameter usage in get_html_from_url()

### DIFF
--- a/mod_scraping.py
+++ b/mod_scraping.py
@@ -37,7 +37,7 @@ def print_header():
     print()
 
 def get_html_from_url(url, headers, proxies):
-    response = requests.get(url, headers=HEADERS, proxies=proxies).content
+    response = requests.get(url, headers=headers, proxies=proxies).content
     # Parse the html content
     soup = BeautifulSoup(response, "html.parser")
     return soup


### PR DESCRIPTION
The get command takes in the global HEADERS variable. 
Should take in the headers parameter supplied through the function call.